### PR TITLE
gosym: PCData comes from pctab, not funcdata

### DIFF
--- a/gosym/symtab.go
+++ b/gosym/symtab.go
@@ -139,7 +139,7 @@ func (f *Func) ForeachTableEntry(off uint32, fn func(val int64, valBytes int, pc
 	if off == 0 {
 		return
 	}
-	data := f.LineTable.funcdata[off:]
+	data := f.LineTable.pctab[off:]
 	pc := f.Entry
 	val := int64(-1)
 


### PR DESCRIPTION
See LineTable.pcvalue and runtime.pcvalue as reference.

This fixes values from PCData and occassional crashes if the garbage we
were reading before happened to be bad varints.