### PR TITLE
Add support for Go 1.18+

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/bradfitz/shotizam
 
-go 1.15
+go 1.21

--- a/gosym/extra.go
+++ b/gosym/extra.go
@@ -5,7 +5,7 @@ import (
 	"log"
 )
 
-func (t *Table) PtrSize() int { return int(t.lt.ptrsize) }
+func (t *Table) PtrSize() int { return int(t.go12line.ptrsize) }
 
 func (f *Func) TableSizePCFile() int { return f.tableSize(f.OffPCFile) }
 func (f *Func) TableSizePCSP() int   { return f.tableSize(f.OffPCSP) }
@@ -16,13 +16,8 @@ func (f *Func) TableSizePCData(tab int) int {
 	if tab >= f.NumPCData || tab < 0 {
 		log.Fatalf("bogus tab %d; NumPCData=%v", tab, f.NumPCData)
 	}
-	fs := funcStruct{f.LineTable, f.funcStructBytes}
-	var tableOff uint32
-	if f.LineTable.version >= ver116 {
-		tableOff = fs.field(9 + tab)
-	} else {
-		tableOff = fs.field(8 + tab)
-	}
+	fs := funcData{f.LineTable, f.funcDataBytes}
+	tableOff := fs.tableOff(uint32(tab))
 	if tableOff == 0 {
 		return 0
 	}
@@ -64,4 +59,45 @@ func (f *Func) ForeachTableEntry(off uint32, fn func(val int64, valBytes int, pc
 
 		fn(val, valBytes, pc, pcBytes)
 	}
+}
+
+/*
+From src/cmd/link/internal/ld/pcln.go.writeFuncs() and src/runtime/runtime2.go._func:
+
+uint32 entryOff;	// offset of func entry PC from textStart
+int32 nameOff;		// name (offset to C string)
+int32 args;			// size of arguments passed to function
+uint32 deferreturn;	// size of function frame, including saved caller PC
+uint32 pcsp;			// pcsp table (offset to pcvalue table)
+uint32 pcfile;		// pcfile table (offset to pcvalue table)
+uint32 pcln;			// pcln table (offset to pcvalue table)
+uint32 npcdata;		// number of entries in pcdata list
+uint32 cuoffset; // 1.16+
+int32 startline; // 1.20+
+uint8 funcID;
+uint8 flag; // 1.17+
+// 1 byte padding or 2 bytes <= 1.16
+uint8 nfuncdata;	// number of entries in funcdata list
+
+*/
+
+func (f funcData) pcsp() uint32   { return f.field(4) }
+func (f funcData) numPCData() int { return int(f.field(7)) }
+
+func (f funcData) numFuncData() int {
+	return int(f.field(f.nfuncdataFieldNum()) & 255)
+}
+
+func (f funcData) nfuncdataFieldNum() uint32 {
+	if f.t.version < ver116 {
+		return 8
+	}
+	if f.t.version < ver120 {
+		return 9
+	}
+	return 10
+}
+
+func (f funcData) tableOff(tab uint32) uint32 {
+	return f.field(f.nfuncdataFieldNum() + 1 + tab)
 }

--- a/gosym/extra.go
+++ b/gosym/extra.go
@@ -1,0 +1,67 @@
+package gosym
+
+import (
+	"encoding/binary"
+	"log"
+)
+
+func (t *Table) PtrSize() int { return int(t.lt.ptrsize) }
+
+func (f *Func) TableSizePCFile() int { return f.tableSize(f.OffPCFile) }
+func (f *Func) TableSizePCSP() int   { return f.tableSize(f.OffPCSP) }
+func (f *Func) TableSizePCLn() int   { return f.tableSize(f.OffPCLn) }
+
+// tab is 0-based table number.
+func (f *Func) TableSizePCData(tab int) int {
+	if tab >= f.NumPCData || tab < 0 {
+		log.Fatalf("bogus tab %d; NumPCData=%v", tab, f.NumPCData)
+	}
+	fs := funcStruct{f.LineTable, f.funcStructBytes}
+	var tableOff uint32
+	if f.LineTable.version >= ver116 {
+		tableOff = fs.field(9 + tab)
+	} else {
+		tableOff = fs.field(8 + tab)
+	}
+	if tableOff == 0 {
+		return 0
+	}
+	return f.tableSize(tableOff)
+}
+
+func (f *Func) tableSize(off uint32) int {
+	sumSize := 0
+	f.ForeachTableEntry(off, func(val int64, valBytes int, pc uint64, pcBytes int) {
+		sumSize += valBytes + pcBytes
+	})
+	return sumSize
+}
+
+func (f *Func) ForeachTableEntry(off uint32, fn func(val int64, valBytes int, pc uint64, pcBytes int)) {
+	if off == 0 {
+		return
+	}
+	data := f.LineTable.pctab[off:]
+	pc := f.Entry
+	val := int64(-1)
+
+	for len(data) > 0 && pc < f.End {
+		vald, valBytes := binary.Varint(data)
+		if valBytes <= 0 {
+			panic("bogus")
+		}
+		val += vald
+		data = data[valBytes:]
+
+		pcd, pcBytes := binary.Uvarint(data)
+		if pcBytes <= 0 {
+			panic("bogus")
+		}
+
+		data = data[pcBytes:]
+		pcd *= uint64(f.LineTable.quantum)
+		pc += pcd
+
+		fn(val, valBytes, pc, pcBytes)
+	}
+}

--- a/gosym/pclntab.go
+++ b/gosym/pclntab.go
@@ -311,6 +311,14 @@ func (t *LineTable) go12Funcs() []Func {
 		info := t.funcData(uint32(i))
 		f.LineTable = t
 		f.FrameSize = int(info.deferreturn())
+
+		f.funcDataBytes = t.funcdata[t.funcTab().funcOff(i):]
+		f.NumPCData = info.numPCData()
+		f.NumFuncData = info.numFuncData()
+		f.OffPCSP = info.pcsp()
+		f.OffPCFile = info.pcfile()
+		f.OffPCLn = info.pcln()
+
 		syms[i] = Sym{
 			Value:     f.Entry,
 			Type:      'T',
@@ -463,10 +471,10 @@ func (f funcData) pcln() uint32        { return f.field(6) }
 func (f funcData) cuOffset() uint32    { return f.field(8) }
 
 // field returns the nth field of the _func struct.
-// It panics if n == 0 or n > 9; for n == 0, call f.entryPC.
+// It panics if n == 0; for n == 0, call f.entryPC.
 // Most callers should use a named field accessor (just above).
 func (f funcData) field(n uint32) uint32 {
-	if n == 0 || n > 9 {
+	if n == 0 {
 		panic("bad funcdata field")
 	}
 	// In Go 1.18, the first field of _func changed

--- a/gosym/pclntab.go
+++ b/gosym/pclntab.go
@@ -1,9 +1,17 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/*
+ * Line tables
+ */
+
 package gosym
 
 import (
 	"bytes"
 	"encoding/binary"
-	"fmt"
+	"sort"
 	"sync"
 )
 
@@ -15,6 +23,8 @@ const (
 	ver11
 	ver12
 	ver116
+	ver118
+	ver120
 )
 
 // A LineTable is a data structure mapping program counters to line numbers.
@@ -33,6 +43,7 @@ const (
 type LineTable struct {
 	Data []byte
 	PC   uint64
+	Line int
 
 	// This mutex is used to keep parsing of pclntab synchronous.
 	mu sync.Mutex
@@ -40,10 +51,11 @@ type LineTable struct {
 	// Contains the version of the pclntab section.
 	version version
 
-	// Go 1.2/1.16 state
+	// Go 1.2/1.16/1.18 state
 	binary      binary.ByteOrder
 	quantum     uint32
 	ptrsize     uint32
+	textStart   uint64 // address of runtime.text symbol (1.18+)
 	funcnametab []byte
 	cutab       []byte
 	funcdata    []byte
@@ -54,31 +66,103 @@ type LineTable struct {
 	nfiletab    uint32
 	funcNames   map[uint32]string // cache the function names
 	strings     map[uint32]string // interned substrings of Data, keyed by offset
-	stringLen   int64             // cumulate len(values(strings))
 	// fileMap varies depending on the version of the object file.
 	// For ver12, it maps the name to the index in the file table.
 	// For ver116, it maps the name to the offset in filetab.
 	fileMap map[string]uint32
 }
 
-func (t *LineTable) String() string {
-	return fmt.Sprintf("LineTable: %d bytes, nfunc=%v (%v bytes), nfile=%d (%v bytes), filemap=%v, strings=%v",
-		len(t.Data),
-		t.nfunctab,
-		len(t.functab),
-		t.nfiletab,
-		len(t.filetab),
-		len(t.fileMap),
-		len(t.strings),
-	)
+// NOTE(rsc): This is wrong for GOARCH=arm, which uses a quantum of 4,
+// but we have no idea whether we're using arm or not. This only
+// matters in the old (pre-Go 1.2) symbol table format, so it's not worth
+// fixing.
+const oldQuantum = 1
+
+func (t *LineTable) parse(targetPC uint64, targetLine int) (b []byte, pc uint64, line int) {
+	// The PC/line table can be thought of as a sequence of
+	//  <pc update>* <line update>
+	// batches. Each update batch results in a (pc, line) pair,
+	// where line applies to every PC from pc up to but not
+	// including the pc of the next pair.
+	//
+	// Here we process each update individually, which simplifies
+	// the code, but makes the corner cases more confusing.
+	b, pc, line = t.Data, t.PC, t.Line
+	for pc <= targetPC && line != targetLine && len(b) > 0 {
+		code := b[0]
+		b = b[1:]
+		switch {
+		case code == 0:
+			if len(b) < 4 {
+				b = b[0:0]
+				break
+			}
+			val := binary.BigEndian.Uint32(b)
+			b = b[4:]
+			line += int(val)
+		case code <= 64:
+			line += int(code)
+		case code <= 128:
+			line -= int(code - 64)
+		default:
+			pc += oldQuantum * uint64(code-128)
+			continue
+		}
+		pc += oldQuantum
+	}
+	return b, pc, line
+}
+
+func (t *LineTable) slice(pc uint64) *LineTable {
+	data, pc, line := t.parse(pc, -1)
+	return &LineTable{Data: data, PC: pc, Line: line}
 }
 
 // PCToLine returns the line number for the given program counter.
 //
 // Deprecated: Use Table's PCToLine method instead.
 func (t *LineTable) PCToLine(pc uint64) int {
-	return t.go12PCToLine(pc)
+	if t.isGo12() {
+		return t.go12PCToLine(pc)
+	}
+	_, _, line := t.parse(pc, -1)
+	return line
 }
+
+// LineToPC returns the program counter for the given line number,
+// considering only program counters before maxpc.
+//
+// Deprecated: Use Table's LineToPC method instead.
+func (t *LineTable) LineToPC(line int, maxpc uint64) uint64 {
+	if t.isGo12() {
+		return 0
+	}
+	_, pc, line1 := t.parse(maxpc, line)
+	if line1 != line {
+		return 0
+	}
+	// Subtract quantum from PC to account for post-line increment
+	return pc - oldQuantum
+}
+
+// NewLineTable returns a new PC/line table
+// corresponding to the encoded data.
+// Text must be the start address of the
+// corresponding text segment.
+func NewLineTable(data []byte, text uint64) *LineTable {
+	return &LineTable{Data: data, PC: text, Line: 0, funcNames: make(map[uint32]string), strings: make(map[uint32]string)}
+}
+
+// Go 1.2 symbol table format.
+// See golang.org/s/go12symtab.
+//
+// A general note about the methods here: rather than try to avoid
+// index out of bounds errors, we trust Go to detect them, and then
+// we recover from the panics and treat them as indicative of a malformed
+// or incomplete table.
+//
+// The methods called by symtab.go, which begin with "go12" prefixes,
+// are expected to have that recovery logic.
 
 // isGo12 reports whether this is a Go 1.2 (or later) symbol table.
 func (t *LineTable) isGo12() bool {
@@ -86,8 +170,12 @@ func (t *LineTable) isGo12() bool {
 	return t.version >= ver12
 }
 
-const go12magic = 0xfffffffb
-const go116magic = 0xfffffffa
+const (
+	go12magic  = 0xfffffffb
+	go116magic = 0xfffffffa
+	go118magic = 0xfffffff0
+	go120magic = 0xfffffff1
+)
 
 // uintptr returns the pointer-sized value encoded at b.
 // The pointer size is dictated by the table being read.
@@ -113,11 +201,12 @@ func (t *LineTable) parsePclnTab() {
 	// Error paths through this code will default the version to 1.1.
 	t.version = ver11
 
-	defer func() {
-		// If we panic parsing, assume it's not a Go 1.2 symbol table.
-		// If we panic parsing, assume it's a Go 1.1 pclntab.
-		recover()
-	}()
+	if !disableRecover {
+		defer func() {
+			// If we panic parsing, assume it's a Go 1.1 pclntab.
+			recover()
+		}()
+	}
 
 	// Check header: 4-byte magic, two zeros, pc quantum, pointer size.
 	if len(t.Data) < 16 || t.Data[4] != 0 || t.Data[5] != 0 ||
@@ -138,30 +227,53 @@ func (t *LineTable) parsePclnTab() {
 		t.binary, possibleVersion = binary.LittleEndian, ver116
 	case beMagic == go116magic:
 		t.binary, possibleVersion = binary.BigEndian, ver116
+	case leMagic == go118magic:
+		t.binary, possibleVersion = binary.LittleEndian, ver118
+	case beMagic == go118magic:
+		t.binary, possibleVersion = binary.BigEndian, ver118
+	case leMagic == go120magic:
+		t.binary, possibleVersion = binary.LittleEndian, ver120
+	case beMagic == go120magic:
+		t.binary, possibleVersion = binary.BigEndian, ver120
 	default:
 		return
 	}
+	t.version = possibleVersion
 
-	// quantum and ptrSize are the same between 1.2 and 1.16
+	// quantum and ptrSize are the same between 1.2, 1.16, and 1.18
 	t.quantum = uint32(t.Data[6])
 	t.ptrsize = uint32(t.Data[7])
 
+	offset := func(word uint32) uint64 {
+		return t.uintptr(t.Data[8+word*t.ptrsize:])
+	}
+	data := func(word uint32) []byte {
+		return t.Data[offset(word):]
+	}
+
 	switch possibleVersion {
+	case ver118, ver120:
+		t.nfunctab = uint32(offset(0))
+		t.nfiletab = uint32(offset(1))
+		t.textStart = t.PC // use the start PC instead of reading from the table, which may be unrelocated
+		t.funcnametab = data(3)
+		t.cutab = data(4)
+		t.filetab = data(5)
+		t.pctab = data(6)
+		t.funcdata = data(7)
+		t.functab = data(7)
+		functabsize := (int(t.nfunctab)*2 + 1) * t.functabFieldSize()
+		t.functab = t.functab[:functabsize]
 	case ver116:
-		t.nfunctab = uint32(t.uintptr(t.Data[8:]))
-		t.nfiletab = uint32(t.uintptr(t.Data[8+t.ptrsize:]))
-		offset := t.uintptr(t.Data[8+2*t.ptrsize:])
-		t.funcnametab = t.Data[offset:]
-		offset = t.uintptr(t.Data[8+3*t.ptrsize:])
-		t.cutab = t.Data[offset:]
-		offset = t.uintptr(t.Data[8+4*t.ptrsize:])
-		t.filetab = t.Data[offset:]
-		offset = t.uintptr(t.Data[8+5*t.ptrsize:])
-		t.pctab = t.Data[offset:]
-		offset = t.uintptr(t.Data[8+6*t.ptrsize:])
-		t.funcdata = t.Data[offset:]
-		t.functab = t.Data[offset:]
-		functabsize := t.nfunctab*2*t.ptrsize + t.ptrsize
+		t.nfunctab = uint32(offset(0))
+		t.nfiletab = uint32(offset(1))
+		t.funcnametab = data(2)
+		t.cutab = data(3)
+		t.filetab = data(4)
+		t.pctab = data(5)
+		t.funcdata = data(6)
+		t.functab = data(6)
+		functabsize := (int(t.nfunctab)*2 + 1) * t.functabFieldSize()
 		t.functab = t.functab[:functabsize]
 	case ver12:
 		t.nfunctab = uint32(t.uintptr(t.Data[8:]))
@@ -169,7 +281,7 @@ func (t *LineTable) parsePclnTab() {
 		t.funcnametab = t.Data
 		t.functab = t.Data[8+t.ptrsize:]
 		t.pctab = t.Data
-		functabsize := t.nfunctab*2*t.ptrsize + t.ptrsize
+		functabsize := (int(t.nfunctab)*2 + 1) * t.functabFieldSize()
 		fileoff := t.binary.Uint32(t.functab[functabsize:])
 		t.functab = t.functab[:functabsize]
 		t.filetab = t.Data[fileoff:]
@@ -178,120 +290,51 @@ func (t *LineTable) parsePclnTab() {
 	default:
 		panic("unreachable")
 	}
-	t.version = possibleVersion
 }
 
-/*
-From doc linked above:
-
-        struct        Func
-        {
-                uintptr        entry;  // start pc
-                int32 name;         // name (offset to C string)
-                int32 args;         // size of arguments passed to function
-                int32 frame;        // size of function frame, including saved caller PC
-                int32        pcsp;                // pcsp table (offset to pcvalue table)
-                int32        pcfile;          // pcfile table (offset to pcvalue table)
-                int32        pcln;                  // pcln table (offset to pcvalue table)
-                int32        nfuncdata;          // number of entries in funcdata list
-                int32        npcdata;          // number of entries in pcdata list
-        };
-*/
-type funcStruct struct {
-	lt  *LineTable
-	enc []byte
-}
-
-func (s funcStruct) entry() uint64 {
-	return s.lt.uintptr(s.enc)
-}
-
-func (s funcStruct) field(n int) uint32 {
-	return s.lt.binary.Uint32(s.enc[int(s.lt.ptrsize)+n*4:])
-}
-
-func (s funcStruct) OffName() uint32   { return s.field(0) }
-func (s funcStruct) ArgSize() int      { return int(s.field(1)) }
-func (s funcStruct) DeferReturn() int  { return int(s.field(2)) }
-func (s funcStruct) OffPCSP() uint32   { return s.field(3) }
-func (s funcStruct) OffPCFile() uint32 { return s.field(4) }
-func (s funcStruct) OffPCLn() uint32   { return s.field(5) }
-func (s funcStruct) NumPCData() int    { return int(s.field(6)) }
-func (s funcStruct) FuncID() int       {
-	if s.lt.version < ver116 {
-		return int(s.field(7) >> 24)
-	}
-	return int(s.field(8) >> 24)
-}
-func (s funcStruct) NumFuncData() int  {
-	if s.lt.version < ver116 {
-		return int(s.field(7) & 255)
-	}
-	return int(s.field(8) & 255)
-}
-
-// go12Funcs returns a slice of Funcs derived from the Go 1.2 pcln table.
+// go12Funcs returns a slice of Funcs derived from the Go 1.2+ pcln table.
 func (t *LineTable) go12Funcs() []Func {
 	// Assume it is malformed and return nil on error.
-	defer func() {
-		recover()
-	}()
+	if !disableRecover {
+		defer func() {
+			recover()
+		}()
+	}
 
-	n := len(t.functab) / int(t.ptrsize) / 2
-	funcs := make([]Func, n)
+	ft := t.funcTab()
+	funcs := make([]Func, ft.Count())
+	syms := make([]Sym, len(funcs))
 	for i := range funcs {
 		f := &funcs[i]
-		f.Entry = t.uintptr(t.functab[2*i*int(t.ptrsize):])
-		f.End = t.uintptr(t.functab[(2*i+2)*int(t.ptrsize):])
-
-		fsOff := t.uintptr(t.functab[(2*i+1)*int(t.ptrsize):])
-		f.OffFixedFunc = fsOff
-		f.funcStructBytes = t.funcdata[fsOff:]
-
-		fs := funcStruct{t, f.funcStructBytes}
-
+		f.Entry = ft.pc(i)
+		f.End = ft.pc(i + 1)
+		info := t.funcData(uint32(i))
 		f.LineTable = t
-		f.ArgSize = fs.ArgSize()
-		f.NumPCData = fs.NumPCData()
-		f.NumFuncData = fs.NumFuncData()
-		f.OffPCSP = fs.OffPCSP()
-		f.OffPCFile = fs.OffPCFile()
-		f.OffPCLn = fs.OffPCLn()
-		f.FuncID = fs.FuncID()
-		f.Sym = &Sym{
-			Value:  f.Entry,
-			Type:   'T',
-			Name:   t.funcName(fs.OffName()),
-			GoType: 0,
-			Func:   f,
+		f.FrameSize = int(info.deferreturn())
+		syms[i] = Sym{
+			Value:     f.Entry,
+			Type:      'T',
+			Name:      t.funcName(info.nameOff()),
+			GoType:    0,
+			Func:      f,
+			goVersion: t.version,
 		}
+		f.Sym = &syms[i]
 	}
 	return funcs
 }
 
-// findFunc returns the func corresponding to the given program counter.
-func (t *LineTable) findFunc(pc uint64) []byte {
-	if pc < t.uintptr(t.functab) || pc >= t.uintptr(t.functab[len(t.functab)-int(t.ptrsize):]) {
-		return nil
+// findFunc returns the funcData corresponding to the given program counter.
+func (t *LineTable) findFunc(pc uint64) funcData {
+	ft := t.funcTab()
+	if pc < ft.pc(0) || pc >= ft.pc(ft.Count()) {
+		return funcData{}
 	}
-
-	// The function table is a list of 2*nfunctab+1 uintptrs,
-	// alternating program counters and offsets to func structures.
-	f := t.functab
-	nf := t.nfunctab
-	for nf > 0 {
-		m := nf / 2
-		fm := f[2*t.ptrsize*m:]
-		if t.uintptr(fm) <= pc && pc < t.uintptr(fm[2*t.ptrsize:]) {
-			return t.funcdata[t.uintptr(fm[t.ptrsize:]):]
-		} else if pc < t.uintptr(fm) {
-			nf = m
-		} else {
-			f = f[(m+1)*2*t.ptrsize:]
-			nf -= m + 1
-		}
-	}
-	return nil
+	idx := sort.Search(int(t.nfunctab), func(i int) bool {
+		return ft.pc(i) > pc
+	})
+	idx--
+	return t.funcData(uint32(idx))
 }
 
 // readvarint reads, removes, and returns a varint from *pp.
@@ -329,8 +372,6 @@ func (t *LineTable) stringFrom(arr []byte, off uint32) string {
 	i := bytes.IndexByte(arr[off:], 0)
 	s := string(arr[off : off+uint32(i)])
 	t.strings[off] = s
-	t.stringLen += int64(len(s))
-	//log.Printf("string@%d = %q, sum %v", off, s, t.stringLen)
 	return s
 }
 
@@ -339,10 +380,104 @@ func (t *LineTable) string(off uint32) string {
 	return t.stringFrom(t.funcdata, off)
 }
 
-func (t *LineTable) StringAtOffset(off uint32) string { return t.string(off) }
+// functabFieldSize returns the size in bytes of a single functab field.
+func (t *LineTable) functabFieldSize() int {
+	if t.version >= ver118 {
+		return 4
+	}
+	return int(t.ptrsize)
+}
 
-func (t *LineTable) Uint32AtOffset(off uint32) uint32 {
-	return t.binary.Uint32(t.Data[off:])
+// funcTab returns t's funcTab.
+func (t *LineTable) funcTab() funcTab {
+	return funcTab{LineTable: t, sz: t.functabFieldSize()}
+}
+
+// funcTab is memory corresponding to a slice of functab structs, followed by an invalid PC.
+// A functab struct is a PC and a func offset.
+type funcTab struct {
+	*LineTable
+	sz int // cached result of t.functabFieldSize
+}
+
+// Count returns the number of func entries in f.
+func (f funcTab) Count() int {
+	return int(f.nfunctab)
+}
+
+// pc returns the PC of the i'th func in f.
+func (f funcTab) pc(i int) uint64 {
+	u := f.uint(f.functab[2*i*f.sz:])
+	if f.version >= ver118 {
+		u += f.textStart
+	}
+	return u
+}
+
+// funcOff returns the funcdata offset of the i'th func in f.
+func (f funcTab) funcOff(i int) uint64 {
+	return f.uint(f.functab[(2*i+1)*f.sz:])
+}
+
+// uint returns the uint stored at b.
+func (f funcTab) uint(b []byte) uint64 {
+	if f.sz == 4 {
+		return uint64(f.binary.Uint32(b))
+	}
+	return f.binary.Uint64(b)
+}
+
+// funcData is memory corresponding to an _func struct.
+type funcData struct {
+	t    *LineTable // LineTable this data is a part of
+	data []byte     // raw memory for the function
+}
+
+// funcData returns the ith funcData in t.functab.
+func (t *LineTable) funcData(i uint32) funcData {
+	data := t.funcdata[t.funcTab().funcOff(int(i)):]
+	return funcData{t: t, data: data}
+}
+
+// IsZero reports whether f is the zero value.
+func (f funcData) IsZero() bool {
+	return f.t == nil && f.data == nil
+}
+
+// entryPC returns the func's entry PC.
+func (f *funcData) entryPC() uint64 {
+	// In Go 1.18, the first field of _func changed
+	// from a uintptr entry PC to a uint32 entry offset.
+	if f.t.version >= ver118 {
+		// TODO: support multiple text sections.
+		// See runtime/symtab.go:(*moduledata).textAddr.
+		return uint64(f.t.binary.Uint32(f.data)) + f.t.textStart
+	}
+	return f.t.uintptr(f.data)
+}
+
+func (f funcData) nameOff() uint32     { return f.field(1) }
+func (f funcData) deferreturn() uint32 { return f.field(3) }
+func (f funcData) pcfile() uint32      { return f.field(5) }
+func (f funcData) pcln() uint32        { return f.field(6) }
+func (f funcData) cuOffset() uint32    { return f.field(8) }
+
+// field returns the nth field of the _func struct.
+// It panics if n == 0 or n > 9; for n == 0, call f.entryPC.
+// Most callers should use a named field accessor (just above).
+func (f funcData) field(n uint32) uint32 {
+	if n == 0 || n > 9 {
+		panic("bad funcdata field")
+	}
+	// In Go 1.18, the first field of _func changed
+	// from a uintptr entry PC to a uint32 entry offset.
+	sz0 := f.t.ptrsize
+	if f.t.version >= ver118 {
+		sz0 = 4
+	}
+	off := sz0 + (n-1)*4 // subsequent fields are 4 bytes each
+	data := f.data[off:]
+	return f.t.binary.Uint32(data)
 }
 
 // step advances to the next pc, value pair in the encoded table.
@@ -399,11 +534,11 @@ func (t *LineTable) findFileLine(entry uint64, filetab, linetab uint32, filenum,
 	fileStartPC := filePC
 	for t.step(&fp, &filePC, &fileVal, filePC == entry) {
 		fileIndex := fileVal
-		if t.version == ver116 {
+		if t.version == ver116 || t.version == ver118 || t.version == ver120 {
 			fileIndex = int32(t.binary.Uint32(cutab[fileVal*4:]))
 		}
 		if fileIndex == filenum && fileStartPC < filePC {
-			// fileVal is in effect starting at fileStartPC up to
+			// fileIndex is in effect starting at fileStartPC up to
 			// but not including filePC, and it's the file we want.
 			// Run the PC table looking for a matching line number
 			// or until we reach filePC.
@@ -426,31 +561,37 @@ func (t *LineTable) findFileLine(entry uint64, filetab, linetab uint32, filenum,
 	return 0
 }
 
-// go12PCToLine maps program counter to line number for the Go 1.2 pcln table.
+// go12PCToLine maps program counter to line number for the Go 1.2+ pcln table.
 func (t *LineTable) go12PCToLine(pc uint64) (line int) {
 	defer func() {
-		if recover() != nil {
+		if !disableRecover && recover() != nil {
 			line = -1
 		}
 	}()
 
 	f := t.findFunc(pc)
-	if f == nil {
+	if f.IsZero() {
 		return -1
 	}
-	entry := t.uintptr(f)
-	linetab := t.binary.Uint32(f[t.ptrsize+5*4:])
+	entry := f.entryPC()
+	linetab := f.pcln()
 	return int(t.pcvalue(linetab, entry, pc))
 }
 
-// pcToFile maps program counter to file name.
-func (t *LineTable) pcToFile(pc uint64) (file string) {
+// go12PCToFile maps program counter to file name for the Go 1.2+ pcln table.
+func (t *LineTable) go12PCToFile(pc uint64) (file string) {
+	defer func() {
+		if !disableRecover && recover() != nil {
+			file = ""
+		}
+	}()
+
 	f := t.findFunc(pc)
-	if f == nil {
+	if f.IsZero() {
 		return ""
 	}
-	entry := t.uintptr(f)
-	filetab := t.binary.Uint32(f[t.ptrsize+4*4:])
+	entry := f.entryPC()
+	filetab := f.pcfile()
 	fno := t.pcvalue(filetab, entry, pc)
 	if t.version == ver12 {
 		if fno <= 0 {
@@ -462,22 +603,17 @@ func (t *LineTable) pcToFile(pc uint64) (file string) {
 	if fno < 0 { // 0 is valid for ≥ 1.16
 		return ""
 	}
-	cuoff := t.binary.Uint32(f[t.ptrsize+7*4:])
+	cuoff := f.cuOffset()
 	if fnoff := t.binary.Uint32(t.cutab[(cuoff+uint32(fno))*4:]); fnoff != ^uint32(0) {
 		return t.stringFrom(t.filetab, fnoff)
 	}
 	return ""
 }
 
-// File returns filename at index n in the file table.
-func (t *LineTable) File(n int) string {
-	return t.string(t.binary.Uint32(t.filetab[4*n:]))
-}
-
-// lineToPC maps a (file, line) pair to a program counter for the Go 1.2/1.16 pcln table.
-func (t *LineTable) lineToPC(file string, line int) (pc uint64) {
+// go12LineToPC maps a (file, line) pair to a program counter for the Go 1.2+ pcln table.
+func (t *LineTable) go12LineToPC(file string, line int) (pc uint64) {
 	defer func() {
-		if recover() != nil {
+		if !disableRecover && recover() != nil {
 			pc = 0
 		}
 	}()
@@ -493,13 +629,16 @@ func (t *LineTable) lineToPC(file string, line int) (pc uint64) {
 	// mapping file number to a list of functions with code from that file.
 	var cutab []byte
 	for i := uint32(0); i < t.nfunctab; i++ {
-		f := t.funcdata[t.uintptr(t.functab[2*t.ptrsize*i+t.ptrsize:]):]
-		entry := t.uintptr(f)
-		filetab := t.binary.Uint32(f[t.ptrsize+4*4:])
-		linetab := t.binary.Uint32(f[t.ptrsize+5*4:])
-		if t.version == ver116 {
-			cuoff := t.binary.Uint32(f[t.ptrsize+7*4:]) * 4
-			cutab = t.cutab[cuoff:]
+		f := t.funcData(i)
+		entry := f.entryPC()
+		filetab := f.pcfile()
+		linetab := f.pcln()
+		if t.version == ver116 || t.version == ver118 || t.version == ver120 {
+			if f.cuOffset() == ^uint32(0) {
+				// skip functions without compilation unit (not real function, or linker generated)
+				continue
+			}
+			cutab = t.cutab[f.cuOffset()*4:]
 		}
 		pc := t.findFileLine(entry, filetab, linetab, int32(filenum), int32(line), cutab)
 		if pc != 0 {
@@ -539,8 +678,18 @@ func (t *LineTable) initFileMap() {
 // Every key maps to obj. That's not a very interesting map, but it provides
 // a way for callers to obtain the list of files in the program.
 func (t *LineTable) go12MapFiles(m map[string]*Obj, obj *Obj) {
+	if !disableRecover {
+		defer func() {
+			recover()
+		}()
+	}
+
 	t.initFileMap()
 	for file := range t.fileMap {
 		m[file] = obj
 	}
 }
+
+// disableRecover causes this package not to swallow panics.
+// This is useful when making changes.
+const disableRecover = false

--- a/gosym/symtab.go
+++ b/gosym/symtab.go
@@ -5,15 +5,11 @@
 // Package gosym implements access to the Go symbol
 // and line number tables embedded in Go binaries generated
 // by the gc compilers.
-//
-// See https://golang.org/s/go12symtab
-//
-// This is a fork of the Go standard library's debug/gosym package,
-// with some stuff added for use by Shotizam.
 package gosym
 
 import (
-	"errors"
+	"bytes"
+	"encoding/binary"
 	"fmt"
 	"strconv"
 	"strings"
@@ -31,19 +27,46 @@ type Sym struct {
 	GoType uint64
 	// If this symbol is a function symbol, the corresponding Func
 	Func *Func
+
+	goVersion version
 }
 
 // Static reports whether this symbol is static (not visible outside its file).
 func (s *Sym) Static() bool { return s.Type >= 'a' }
 
+// nameWithoutInst returns s.Name if s.Name has no brackets (does not reference an
+// instantiated type, function, or method). If s.Name contains brackets, then it
+// returns s.Name with all the contents between (and including) the outermost left
+// and right bracket removed. This is useful to ignore any extra slashes or dots
+// inside the brackets from the string searches below, where needed.
+func (s *Sym) nameWithoutInst() string {
+	start := strings.Index(s.Name, "[")
+	if start < 0 {
+		return s.Name
+	}
+	end := strings.LastIndex(s.Name, "]")
+	if end < 0 {
+		// Malformed name, should contain closing bracket too.
+		return s.Name
+	}
+	return s.Name[0:start] + s.Name[end+1:]
+}
+
 // PackageName returns the package part of the symbol name,
 // or the empty string if there is none.
 func (s *Sym) PackageName() string {
-	name := s.Name
+	name := s.nameWithoutInst()
 
-	// A prefix of "type." and "go." is a compiler-generated symbol that doesn't belong to any package.
-	// See variable reservedimports in cmd/compile/internal/gc/subr.go
-	if strings.HasPrefix(name, "go.") || strings.HasPrefix(name, "type.") {
+	// Since go1.20, a prefix of "type:" and "go:" is a compiler-generated symbol,
+	// they do not belong to any package.
+	//
+	// See cmd/compile/internal/base/link.go:ReservedImports variable.
+	if s.goVersion >= ver120 && (strings.HasPrefix(name, "go:") || strings.HasPrefix(name, "type:")) {
+		return ""
+	}
+
+	// For go1.18 and below, the prefix are "type." and "go." instead.
+	if s.goVersion <= ver118 && (strings.HasPrefix(name, "go.") || strings.HasPrefix(name, "type.")) {
 		return ""
 	}
 
@@ -59,23 +82,46 @@ func (s *Sym) PackageName() string {
 }
 
 // ReceiverName returns the receiver type name of this symbol,
-// or the empty string if there is none.
+// or the empty string if there is none.  A receiver name is only detected in
+// the case that s.Name is fully-specified with a package name.
 func (s *Sym) ReceiverName() string {
-	pathend := strings.LastIndex(s.Name, "/")
+	name := s.nameWithoutInst()
+	// If we find a slash in name, it should precede any bracketed expression
+	// that was removed, so pathend will apply correctly to name and s.Name.
+	pathend := strings.LastIndex(name, "/")
 	if pathend < 0 {
 		pathend = 0
 	}
-	l := strings.Index(s.Name[pathend:], ".")
-	r := strings.LastIndex(s.Name[pathend:], ".")
+	// Find the first dot after pathend (or from the beginning, if there was
+	// no slash in name).
+	l := strings.Index(name[pathend:], ".")
+	// Find the last dot after pathend (or the beginning).
+	r := strings.LastIndex(name[pathend:], ".")
 	if l == -1 || r == -1 || l == r {
+		// There is no receiver if we didn't find two distinct dots after pathend.
 		return ""
 	}
+	// Given there is a trailing '.' that is in name, find it now in s.Name.
+	// pathend+l should apply to s.Name, because it should be the dot in the
+	// package name.
+	r = strings.LastIndex(s.Name[pathend:], ".")
 	return s.Name[pathend+l+1 : pathend+r]
 }
 
 // BaseName returns the symbol name without the package or receiver name.
 func (s *Sym) BaseName() string {
-	if i := strings.LastIndex(s.Name, "."); i != -1 {
+	name := s.nameWithoutInst()
+	if i := strings.LastIndex(name, "."); i != -1 {
+		if s.Name != name {
+			brack := strings.Index(s.Name, "[")
+			if i > brack {
+				// BaseName is a method name after the brackets, so
+				// recalculate for s.Name. Otherwise, i applies
+				// correctly to s.Name, since it is before the
+				// brackets.
+				i = strings.LastIndex(s.Name, ".")
+			}
+		}
 		return s.Name[i+1:]
 	}
 	return s.Name
@@ -86,21 +132,11 @@ type Func struct {
 	Entry uint64
 	*Sym
 	End       uint64
+	Params    []*Sym // nil for Go 1.3 and later binaries
+	Locals    []*Sym // nil for Go 1.3 and later binaries
+	FrameSize int
 	LineTable *LineTable
 	Obj       *Obj
-
-	OffFixedFunc uint64
-
-	ArgSize     int    // in/out args size
-	DeferReturn int    // offset of start of a deferreturn call instruction from entry, if any.
-	OffPCSP     uint32 // pcsp table (offset from pcvalue table)
-	OffPCFile   uint32 // pcfile table (offset from pcvalue table)
-	OffPCLn     uint32 // pcln table (offset from pcvalue table)
-	NumPCData   int    // number of entries in pcdata list
-	NumFuncData int    // number of entries in funcdata list
-	FuncID      int    // special runtime func ID (for some runtime funcs)
-
-	funcStructBytes []byte
 }
 
 // An Obj represents a collection of functions in a symbol table.
@@ -117,6 +153,12 @@ type Func struct {
 type Obj struct {
 	// Funcs is a list of functions in the Obj.
 	Funcs []Func
+
+	// In Go 1.1 and earlier, Paths is a list of symbols corresponding
+	// to the source file names that produced the Obj.
+	// In Go 1.2, Paths is nil.
+	// Use the keys of Table.Files to obtain a list of source files.
+	Paths []Sym // meta
 }
 
 /*
@@ -127,40 +169,366 @@ type Obj struct {
 // symbols decoded from the program and provides methods to translate
 // between symbols, names, and addresses.
 type Table struct {
+	Syms  []Sym // nil for Go 1.3 and later binaries
 	Funcs []Func
-	Files map[string]*Obj // nil for Go 1.2 and later binaries
-	Objs  []Obj           // nil for Go 1.2 and later binaries
+	Files map[string]*Obj // for Go 1.2 and later all files map to one Obj
+	Objs  []Obj           // for Go 1.2 and later only one Obj in slice
 
-	lt *LineTable // Go 1.2 line number table
+	go12line *LineTable // Go 1.2 line number table
 }
 
-// NewTable returns a new PC/line table
-// corresponding to the encoded data.
-// Text must be the start address of the
-// corresponding text segment.
-func NewTable(data []byte, text uint64) (*Table, error) {
-	lt := &LineTable{
-		Data:      data,
-		PC:        text,
-		funcNames: make(map[uint32]string),
-		strings:   make(map[uint32]string),
+type sym struct {
+	value  uint64
+	gotype uint64
+	typ    byte
+	name   []byte
+}
+
+var (
+	littleEndianSymtab    = []byte{0xFD, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00}
+	bigEndianSymtab       = []byte{0xFF, 0xFF, 0xFF, 0xFD, 0x00, 0x00, 0x00}
+	oldLittleEndianSymtab = []byte{0xFE, 0xFF, 0xFF, 0xFF, 0x00, 0x00}
+)
+
+func walksymtab(data []byte, fn func(sym) error) error {
+	if len(data) == 0 { // missing symtab is okay
+		return nil
+	}
+	var order binary.ByteOrder = binary.BigEndian
+	newTable := false
+	switch {
+	case bytes.HasPrefix(data, oldLittleEndianSymtab):
+		// Same as Go 1.0, but little endian.
+		// Format was used during interim development between Go 1.0 and Go 1.1.
+		// Should not be widespread, but easy to support.
+		data = data[6:]
+		order = binary.LittleEndian
+	case bytes.HasPrefix(data, bigEndianSymtab):
+		newTable = true
+	case bytes.HasPrefix(data, littleEndianSymtab):
+		newTable = true
+		order = binary.LittleEndian
+	}
+	var ptrsz int
+	if newTable {
+		if len(data) < 8 {
+			return &DecodingError{len(data), "unexpected EOF", nil}
+		}
+		ptrsz = int(data[7])
+		if ptrsz != 4 && ptrsz != 8 {
+			return &DecodingError{7, "invalid pointer size", ptrsz}
+		}
+		data = data[8:]
+	}
+	var s sym
+	p := data
+	for len(p) >= 4 {
+		var typ byte
+		if newTable {
+			// Symbol type, value, Go type.
+			typ = p[0] & 0x3F
+			wideValue := p[0]&0x40 != 0
+			goType := p[0]&0x80 != 0
+			if typ < 26 {
+				typ += 'A'
+			} else {
+				typ += 'a' - 26
+			}
+			s.typ = typ
+			p = p[1:]
+			if wideValue {
+				if len(p) < ptrsz {
+					return &DecodingError{len(data), "unexpected EOF", nil}
+				}
+				// fixed-width value
+				if ptrsz == 8 {
+					s.value = order.Uint64(p[0:8])
+					p = p[8:]
+				} else {
+					s.value = uint64(order.Uint32(p[0:4]))
+					p = p[4:]
+				}
+			} else {
+				// varint value
+				s.value = 0
+				shift := uint(0)
+				for len(p) > 0 && p[0]&0x80 != 0 {
+					s.value |= uint64(p[0]&0x7F) << shift
+					shift += 7
+					p = p[1:]
+				}
+				if len(p) == 0 {
+					return &DecodingError{len(data), "unexpected EOF", nil}
+				}
+				s.value |= uint64(p[0]) << shift
+				p = p[1:]
+			}
+			if goType {
+				if len(p) < ptrsz {
+					return &DecodingError{len(data), "unexpected EOF", nil}
+				}
+				// fixed-width go type
+				if ptrsz == 8 {
+					s.gotype = order.Uint64(p[0:8])
+					p = p[8:]
+				} else {
+					s.gotype = uint64(order.Uint32(p[0:4]))
+					p = p[4:]
+				}
+			}
+		} else {
+			// Value, symbol type.
+			s.value = uint64(order.Uint32(p[0:4]))
+			if len(p) < 5 {
+				return &DecodingError{len(data), "unexpected EOF", nil}
+			}
+			typ = p[4]
+			if typ&0x80 == 0 {
+				return &DecodingError{len(data) - len(p) + 4, "bad symbol type", typ}
+			}
+			typ &^= 0x80
+			s.typ = typ
+			p = p[5:]
+		}
+
+		// Name.
+		var i int
+		var nnul int
+		for i = 0; i < len(p); i++ {
+			if p[i] == 0 {
+				nnul = 1
+				break
+			}
+		}
+		switch typ {
+		case 'z', 'Z':
+			p = p[i+nnul:]
+			for i = 0; i+2 <= len(p); i += 2 {
+				if p[i] == 0 && p[i+1] == 0 {
+					nnul = 2
+					break
+				}
+			}
+		}
+		if len(p) < i+nnul {
+			return &DecodingError{len(data), "unexpected EOF", nil}
+		}
+		s.name = p[0:i]
+		i += nnul
+		p = p[i:]
+
+		if !newTable {
+			if len(p) < 4 {
+				return &DecodingError{len(data), "unexpected EOF", nil}
+			}
+			// Go type.
+			s.gotype = uint64(order.Uint32(p[:4]))
+			p = p[4:]
+		}
+		fn(s)
+	}
+	return nil
+}
+
+// NewTable decodes the Go symbol table (the ".gosymtab" section in ELF),
+// returning an in-memory representation.
+// Starting with Go 1.3, the Go symbol table no longer includes symbol data.
+func NewTable(symtab []byte, pcln *LineTable) (*Table, error) {
+	var n int
+	err := walksymtab(symtab, func(s sym) error {
+		n++
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	var t Table
-	if !lt.isGo12() {
-		return nil, errors.New("not a go1.2+ line table")
+	if pcln.isGo12() {
+		t.go12line = pcln
 	}
-	t.lt = lt
-	t.Funcs = make([]Func, 0)
+	fname := make(map[uint16]string)
+	t.Syms = make([]Sym, 0, n)
+	nf := 0
+	nz := 0
+	lasttyp := uint8(0)
+	err = walksymtab(symtab, func(s sym) error {
+		n := len(t.Syms)
+		t.Syms = t.Syms[0 : n+1]
+		ts := &t.Syms[n]
+		ts.Type = s.typ
+		ts.Value = s.value
+		ts.GoType = s.gotype
+		ts.goVersion = pcln.version
+		switch s.typ {
+		default:
+			// rewrite name to use . instead of · (c2 b7)
+			w := 0
+			b := s.name
+			for i := 0; i < len(b); i++ {
+				if b[i] == 0xc2 && i+1 < len(b) && b[i+1] == 0xb7 {
+					i++
+					b[i] = '.'
+				}
+				b[w] = b[i]
+				w++
+			}
+			ts.Name = string(s.name[0:w])
+		case 'z', 'Z':
+			if lasttyp != 'z' && lasttyp != 'Z' {
+				nz++
+			}
+			for i := 0; i < len(s.name); i += 2 {
+				eltIdx := binary.BigEndian.Uint16(s.name[i : i+2])
+				elt, ok := fname[eltIdx]
+				if !ok {
+					return &DecodingError{-1, "bad filename code", eltIdx}
+				}
+				if n := len(ts.Name); n > 0 && ts.Name[n-1] != '/' {
+					ts.Name += "/"
+				}
+				ts.Name += elt
+			}
+		}
+		switch s.typ {
+		case 'T', 't', 'L', 'l':
+			nf++
+		case 'f':
+			fname[uint16(s.value)] = ts.Name
+		}
+		lasttyp = s.typ
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	t.Funcs = make([]Func, 0, nf)
 	t.Files = make(map[string]*Obj)
 
-	// Put all functions into one Obj.
-	t.Objs = make([]Obj, 1)
-	obj := &t.Objs[0]
-	t.lt.go12MapFiles(t.Files, obj)
+	var obj *Obj
+	if t.go12line != nil {
+		// Put all functions into one Obj.
+		t.Objs = make([]Obj, 1)
+		obj = &t.Objs[0]
+		t.go12line.go12MapFiles(t.Files, obj)
+	} else {
+		t.Objs = make([]Obj, 0, nz)
+	}
 
-	t.Funcs = t.lt.go12Funcs()
-	obj.Funcs = t.Funcs
+	// Count text symbols and attach frame sizes, parameters, and
+	// locals to them. Also, find object file boundaries.
+	lastf := 0
+	for i := 0; i < len(t.Syms); i++ {
+		sym := &t.Syms[i]
+		switch sym.Type {
+		case 'Z', 'z': // path symbol
+			if t.go12line != nil {
+				// Go 1.2 binaries have the file information elsewhere. Ignore.
+				break
+			}
+			// Finish the current object
+			if obj != nil {
+				obj.Funcs = t.Funcs[lastf:]
+			}
+			lastf = len(t.Funcs)
+
+			// Start new object
+			n := len(t.Objs)
+			t.Objs = t.Objs[0 : n+1]
+			obj = &t.Objs[n]
+
+			// Count & copy path symbols
+			var end int
+			for end = i + 1; end < len(t.Syms); end++ {
+				if c := t.Syms[end].Type; c != 'Z' && c != 'z' {
+					break
+				}
+			}
+			obj.Paths = t.Syms[i:end]
+			i = end - 1 // loop will i++
+
+			// Record file names
+			depth := 0
+			for j := range obj.Paths {
+				s := &obj.Paths[j]
+				if s.Name == "" {
+					depth--
+				} else {
+					if depth == 0 {
+						t.Files[s.Name] = obj
+					}
+					depth++
+				}
+			}
+
+		case 'T', 't', 'L', 'l': // text symbol
+			if n := len(t.Funcs); n > 0 {
+				t.Funcs[n-1].End = sym.Value
+			}
+			if sym.Name == "runtime.etext" || sym.Name == "etext" {
+				continue
+			}
+
+			// Count parameter and local (auto) syms
+			var np, na int
+			var end int
+		countloop:
+			for end = i + 1; end < len(t.Syms); end++ {
+				switch t.Syms[end].Type {
+				case 'T', 't', 'L', 'l', 'Z', 'z':
+					break countloop
+				case 'p':
+					np++
+				case 'a':
+					na++
+				}
+			}
+
+			// Fill in the function symbol
+			n := len(t.Funcs)
+			t.Funcs = t.Funcs[0 : n+1]
+			fn := &t.Funcs[n]
+			sym.Func = fn
+			fn.Params = make([]*Sym, 0, np)
+			fn.Locals = make([]*Sym, 0, na)
+			fn.Sym = sym
+			fn.Entry = sym.Value
+			fn.Obj = obj
+			if t.go12line != nil {
+				// All functions share the same line table.
+				// It knows how to narrow down to a specific
+				// function quickly.
+				fn.LineTable = t.go12line
+			} else if pcln != nil {
+				fn.LineTable = pcln.slice(fn.Entry)
+				pcln = fn.LineTable
+			}
+			for j := i; j < end; j++ {
+				s := &t.Syms[j]
+				switch s.Type {
+				case 'm':
+					fn.FrameSize = int(s.Value)
+				case 'p':
+					n := len(fn.Params)
+					fn.Params = fn.Params[0 : n+1]
+					fn.Params[n] = s
+				case 'a':
+					n := len(fn.Locals)
+					fn.Locals = fn.Locals[0 : n+1]
+					fn.Locals[n] = s
+				}
+			}
+			i = end - 1 // loop will i++
+		}
+	}
+
+	if t.go12line != nil && nf == 0 {
+		t.Funcs = t.go12line.go12Funcs()
+	}
+	if obj != nil {
+		obj.Funcs = t.Funcs[lastf:]
+	}
 	return &t, nil
 }
 
@@ -189,8 +557,12 @@ func (t *Table) PCToLine(pc uint64) (file string, line int, fn *Func) {
 	if fn = t.PCToFunc(pc); fn == nil {
 		return
 	}
-	file = t.lt.pcToFile(pc)
-	line = t.lt.go12PCToLine(pc)
+	if t.go12line != nil {
+		file = t.go12line.go12PCToFile(pc)
+		line = t.go12line.go12PCToLine(pc)
+	} else {
+		file, line = fn.Obj.lineFromAline(fn.LineTable.PCToLine(pc))
+	}
 	return
 }
 
@@ -198,15 +570,47 @@ func (t *Table) PCToLine(pc uint64) (file string, line int, fn *Func) {
 // the named file. It returns UnknownPathError or UnknownLineError if
 // there is an error looking up this line.
 func (t *Table) LineToPC(file string, line int) (pc uint64, fn *Func, err error) {
-	_, ok := t.Files[file]
+	obj, ok := t.Files[file]
 	if !ok {
 		return 0, nil, UnknownFileError(file)
 	}
-	pc = t.lt.lineToPC(file, line)
-	if pc == 0 {
-		return 0, nil, &UnknownLineError{file, line}
+
+	if t.go12line != nil {
+		pc := t.go12line.go12LineToPC(file, line)
+		if pc == 0 {
+			return 0, nil, &UnknownLineError{file, line}
+		}
+		return pc, t.PCToFunc(pc), nil
 	}
-	return pc, t.PCToFunc(pc), nil
+
+	abs, err := obj.alineFromLine(file, line)
+	if err != nil {
+		return
+	}
+	for i := range obj.Funcs {
+		f := &obj.Funcs[i]
+		pc := f.LineTable.LineToPC(abs, f.End)
+		if pc != 0 {
+			return pc, f, nil
+		}
+	}
+	return 0, nil, &UnknownLineError{file, line}
+}
+
+// LookupSym returns the text, data, or bss symbol with the given name,
+// or nil if no such symbol is found.
+func (t *Table) LookupSym(name string) *Sym {
+	// TODO(austin) Maybe make a map
+	for i := range t.Syms {
+		s := &t.Syms[i]
+		switch s.Type {
+		case 'T', 't', 'L', 'l', 'D', 'd', 'B', 'b':
+			if s.Name == name {
+				return s
+			}
+		}
+	}
+	return nil
 }
 
 // LookupFunc returns the text, data, or bss symbol with the given name,
@@ -219,6 +623,115 @@ func (t *Table) LookupFunc(name string) *Func {
 		}
 	}
 	return nil
+}
+
+// SymByAddr returns the text, data, or bss symbol starting at the given address.
+func (t *Table) SymByAddr(addr uint64) *Sym {
+	for i := range t.Syms {
+		s := &t.Syms[i]
+		switch s.Type {
+		case 'T', 't', 'L', 'l', 'D', 'd', 'B', 'b':
+			if s.Value == addr {
+				return s
+			}
+		}
+	}
+	return nil
+}
+
+/*
+ * Object files
+ */
+
+// This is legacy code for Go 1.1 and earlier, which used the
+// Plan 9 format for pc-line tables. This code was never quite
+// correct. It's probably very close, and it's usually correct, but
+// we never quite found all the corner cases.
+//
+// Go 1.2 and later use a simpler format, documented at golang.org/s/go12symtab.
+
+func (o *Obj) lineFromAline(aline int) (string, int) {
+	type stackEnt struct {
+		path   string
+		start  int
+		offset int
+		prev   *stackEnt
+	}
+
+	noPath := &stackEnt{"", 0, 0, nil}
+	tos := noPath
+
+pathloop:
+	for _, s := range o.Paths {
+		val := int(s.Value)
+		switch {
+		case val > aline:
+			break pathloop
+
+		case val == 1:
+			// Start a new stack
+			tos = &stackEnt{s.Name, val, 0, noPath}
+
+		case s.Name == "":
+			// Pop
+			if tos == noPath {
+				return "<malformed symbol table>", 0
+			}
+			tos.prev.offset += val - tos.start
+			tos = tos.prev
+
+		default:
+			// Push
+			tos = &stackEnt{s.Name, val, 0, tos}
+		}
+	}
+
+	if tos == noPath {
+		return "", 0
+	}
+	return tos.path, aline - tos.start - tos.offset + 1
+}
+
+func (o *Obj) alineFromLine(path string, line int) (int, error) {
+	if line < 1 {
+		return 0, &UnknownLineError{path, line}
+	}
+
+	for i, s := range o.Paths {
+		// Find this path
+		if s.Name != path {
+			continue
+		}
+
+		// Find this line at this stack level
+		depth := 0
+		var incstart int
+		line += int(s.Value)
+	pathloop:
+		for _, s := range o.Paths[i:] {
+			val := int(s.Value)
+			switch {
+			case depth == 1 && val >= line:
+				return line - 1, nil
+
+			case s.Name == "":
+				depth--
+				if depth == 0 {
+					break pathloop
+				} else if depth == 1 {
+					line += val - incstart
+				}
+
+			default:
+				if depth == 1 {
+					incstart = val
+				}
+				depth++
+			}
+		}
+		return 0, &UnknownLineError{path, line}
+	}
+	return 0, UnknownFileError(path)
 }
 
 /*
@@ -248,7 +761,7 @@ func (e *UnknownLineError) Error() string {
 type DecodingError struct {
 	off int
 	msg string
-	val interface{}
+	val any
 }
 
 func (e *DecodingError) Error() string {

--- a/gosym/symtab.go
+++ b/gosym/symtab.go
@@ -5,6 +5,11 @@
 // Package gosym implements access to the Go symbol
 // and line number tables embedded in Go binaries generated
 // by the gc compilers.
+//
+// See https://golang.org/s/go12symtab
+//
+// This is a fork of the Go standard library's debug/gosym package,
+// with some stuff added for use by Shotizam.
 package gosym
 
 import (
@@ -137,6 +142,14 @@ type Func struct {
 	FrameSize int
 	LineTable *LineTable
 	Obj       *Obj
+
+	OffPCSP     uint32 // pcsp table (offset from pcvalue table)
+	OffPCFile   uint32 // pcfile table (offset from pcvalue table)
+	OffPCLn     uint32 // pcln table (offset from pcvalue table)
+	NumPCData   int    // number of entries in pcdata list
+	NumFuncData int    // number of entries in funcdata list
+
+	funcDataBytes []byte
 }
 
 // An Obj represents a collection of functions in a symbol table.

--- a/gosym/symtab.go
+++ b/gosym/symtab.go
@@ -13,10 +13,8 @@
 package gosym
 
 import (
-	"encoding/binary"
 	"errors"
 	"fmt"
-	"log"
 	"strconv"
 	"strings"
 )
@@ -105,65 +103,6 @@ type Func struct {
 	funcStructBytes []byte
 }
 
-func (f *Func) TableSizePCFile() int { return f.tableSize(f.OffPCFile) }
-func (f *Func) TableSizePCSP() int   { return f.tableSize(f.OffPCSP) }
-func (f *Func) TableSizePCLn() int   { return f.tableSize(f.OffPCLn) }
-
-// tab is 0-based table number.
-func (f *Func) TableSizePCData(tab int) int {
-	if tab >= f.NumPCData || tab < 0 {
-		log.Fatalf("bogus tab %d; NumPCData=%v", tab, f.NumPCData)
-	}
-	fs := funcStruct{f.LineTable, f.funcStructBytes}
-	var tableOff uint32
-	if f.LineTable.version >= ver116 {
-		tableOff = fs.field(9 + tab)
-	} else {
-		tableOff = fs.field(8 + tab)
-	}
-	if tableOff == 0 {
-		return 0
-	}
-	return f.tableSize(tableOff)
-}
-
-func (f *Func) tableSize(off uint32) int {
-	sumSize := 0
-	f.ForeachTableEntry(off, func(val int64, valBytes int, pc uint64, pcBytes int) {
-		sumSize += valBytes + pcBytes
-	})
-	return sumSize
-}
-
-func (f *Func) ForeachTableEntry(off uint32, fn func(val int64, valBytes int, pc uint64, pcBytes int)) {
-	if off == 0 {
-		return
-	}
-	data := f.LineTable.pctab[off:]
-	pc := f.Entry
-	val := int64(-1)
-
-	for len(data) > 0 && pc < f.End {
-		vald, valBytes := binary.Varint(data)
-		if valBytes <= 0 {
-			panic("bogus")
-		}
-		val += vald
-		data = data[valBytes:]
-
-		pcd, pcBytes := binary.Uvarint(data)
-		if pcBytes <= 0 {
-			panic("bogus")
-		}
-
-		data = data[pcBytes:]
-		pcd *= uint64(f.LineTable.quantum)
-		pc += pcd
-
-		fn(val, valBytes, pc, pcBytes)
-	}
-}
-
 // An Obj represents a collection of functions in a symbol table.
 //
 // The exact method of division of a binary into separate Objs is an internal detail
@@ -224,8 +163,6 @@ func NewTable(data []byte, text uint64) (*Table, error) {
 	obj.Funcs = t.Funcs
 	return &t, nil
 }
-
-func (t *Table) PtrSize() int { return int(t.lt.ptrsize) }
 
 // PCToFunc returns the function containing the program counter pc,
 // or nil if there is no such function.


### PR DESCRIPTION
I haven't done extensive testing, but this builds and seems to work against binaries built using Go 1.21. This pulls in the `debug/gosym` non-test files from go 1.21.9.